### PR TITLE
Feature/openapi #5

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -4,6 +4,6 @@ COPY init.sql /docker-entrypoint-initdb.d
 
 ENV MYSQL_ROOT_PASSWORD=root1234
 ENV MYSQL_DATABASE=metadb
-ENV MYSQL_HOST=%
+ENV MYSQL_HOST=localhost
 
 CMD ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci"]

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+application-secret.yml

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 	id("org.springframework.boot") version "3.4.1"
 	id("io.spring.dependency-management") version "1.1.7"
 }
+val springAiVersion by extra("1.0.0-M4")
 
 group = "com.ll"
 version = "0.0.1-SNAPSHOT"
@@ -13,6 +14,8 @@ java {
 	}
 }
 
+
+
 configurations {
 	compileOnly {
 		extendsFrom(configurations.annotationProcessor.get())
@@ -21,11 +24,16 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {
+		url = uri("https://repo.spring.io/milestone")
+	}
 }
+
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.ai:spring-ai-openai-spring-boot-starter")
 	compileOnly("org.projectlombok:lombok")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("com.h2database:h2")
@@ -33,7 +41,14 @@ dependencies {
 	annotationProcessor("org.projectlombok:lombok")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
 }
+dependencyManagement {
+	imports {
+		mavenBom("org.springframework.ai:spring-ai-bom:$springAiVersion")
+	}
+}
+
 
 tasks.withType<Test> {
 	useJUnitPlatform()

--- a/server/src/main/java/com/ll/server/domain/news/news/controller/ApiV1NewsController.java
+++ b/server/src/main/java/com/ll/server/domain/news/news/controller/ApiV1NewsController.java
@@ -2,9 +2,10 @@ package com.ll.server.domain.news.news.controller;
 
 import com.ll.server.domain.news.news.service.NewsService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -12,9 +13,33 @@ import org.springframework.web.bind.annotation.RestController;
 public class ApiV1NewsController {
 
     private final NewsService newsService;
+    private final OpenAiChatModel openAiChatModel;
+
 
     @GetMapping("/getAll")
     public String getAll() {
         return newsService.getAll().toString();
     }
+
+    @PostMapping("/ai")
+    public String gptApiTest(@RequestBody Map<String, String> request){
+        String article1=request.getOrDefault("article1","");
+        String article2=request.getOrDefault("article2","");
+        if(article1==null || article1.isBlank()) {
+            article1 = "도널드 트럼프 미국 대통령이 20일 열린 취임식에서 “미국의 황금기는 이제 막 시작되었다”고 연설하며 남부 국경에서의 국가 비상 사태를 선포했다.";
+        }
+        if(article2==null || article2.isBlank()) {
+            article2 = "①인플레 종식 ②감세 ③국경강화 ④힘 통한 평화 ⑤에너지 패권 ⑥안전한 도시 홈페이지에 바이든 썼던 구호 재사용 “바이든 정책 모두 되돌리겠다” 시사";
+        }
+        return getAiResponse(article1,article2);
+    }
+
+    private String getAiResponse(String article1Summary, String article2Summary){
+        String prompt="기사1: [summary1]\n기사2: [summary]\n\n기사1은 대한민국의 헤럴드 경제 언론사의 기사고, 기사2는 미국의 BBC 언론사의 기사야. 두 기사는 비슷한 주제를 다루는 기사야. 그 주제가 무엇인지 두 기사를 보고 알아낸 다음, 두 나라가 그 주제에 대해 어떤 시각을 가지는지 각각에 대해 다음과 같이 답을 만들어줘.\n"
+                +"나라 - 언론사: (여기에 각 기사가 어떤 것을 중점으로 보고 있는지 작성해줘.)";
+        prompt=prompt.replace("[summary1]",article1Summary).replace("[summary2]",article2Summary);
+        return openAiChatModel.call(prompt);
+    }
+
+
 }

--- a/server/src/main/resources/application-secret.yml.default
+++ b/server/src/main/resources/application-secret.yml.default
@@ -1,0 +1,4 @@
+spring:
+  ai:
+    openai:
+      api-key: NEED_TO_INPUT

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -2,3 +2,5 @@ spring:
   profiles:
     active:
       - dev
+    include:
+      - secret


### PR DESCRIPTION
openai api에 대한 의존성을 추가하였고, 키를 추가하면 postman을 통해 테스트할 수 있습니다.

POST로 메서드 변경 후
localhost:8080/api/v1/news/ai

body는 raw로 한 후 {} 이렇게 비워도 되고 {"article1":"...", "article2":"..."} 이렇게 보내셔도 됩니다.