### PR TITLE
fix: fix alarm message and implement news subscription temporarily

### DIFF
--- a/mysql/init.sql
+++ b/mysql/init.sql
@@ -1,4 +1,4 @@
---CREATE TABLE news (
+--CREATE TABLE mockNews (
 --    id BIGINT AUTO_INCREMENT PRIMARY KEY,
 --    title VARCHAR(255) NOT NULL,
 --    content TEXT,
@@ -9,8 +9,8 @@
 --
 ---- News 테이블 초기 데이터 삽입
 --
---INSERT INTO news (title, content, author, create_date, modify_date)
+--INSERT INTO mockNews (title, content, author, create_date, modify_date)
 --VALUES
---    ('First News Title', 'This is the content of the first news article.', 'Author 1', NOW(), NOW()),
---    ('Second News Title', 'This is the content of the second news article.', 'Author 2', NOW(), NOW()),
---    ('Third News Title', 'This is the content of the third news article.', 'Author 3', NOW(), NOW());
+--    ('First News Title', 'This is the content of the first mockNews article.', 'Author 1', NOW(), NOW()),
+--    ('Second News Title', 'This is the content of the second mockNews article.', 'Author 2', NOW(), NOW()),
+--    ('Third News Title', 'This is the content of the third mockNews article.', 'Author 3', NOW(), NOW());

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 group = "com.ll"
 version = "0.0.1-SNAPSHOT"
-val springAiVersion by extra("1.0.0-M4")
 val springCloudVersion by extra("2024.0.0")
 
 java {
@@ -48,7 +47,6 @@ dependencies {
 dependencyManagement {
 	imports {
 		mavenBom("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}")
-		mavenBom("org.springframework.ai:spring-ai-bom:${springAiVersion}")
 	}
 }
 tasks.withType<Test> {

--- a/server/src/main/java/com/ll/server/domain/mock/like/dto/MockLikeDTO.java
+++ b/server/src/main/java/com/ll/server/domain/mock/like/dto/MockLikeDTO.java
@@ -18,7 +18,7 @@ public class MockLikeDTO {
     public MockLikeDTO(MockLike like){
         id=like.getId();
         repostId=like.getRepost().getId();
-        repostWriterId=like.getUser().getId();
+        repostWriterId=like.getRepost().getUser().getId();
         checkedUserId=like.getUser().getId();
         checkedUserName=like.getUser().getNickname();
     }

--- a/server/src/main/java/com/ll/server/domain/mock/news/controller/ApiV1MockNewsController.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/controller/ApiV1MockNewsController.java
@@ -1,0 +1,46 @@
+package com.ll.server.domain.mock.news.controller;
+
+import com.ll.server.domain.mock.news.dto.MockNewsDTO;
+import com.ll.server.domain.mock.news.dto.NewsUpdateRequest;
+import com.ll.server.domain.mock.news.service.MockNewsService;
+import com.ll.server.global.response.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/mock/news")
+public class ApiV1MockNewsController {
+
+    private final MockNewsService mockNewsService;
+
+    @GetMapping
+    public List<MockNewsDTO> getAll() {
+        return mockNewsService.getAll();
+    }
+
+    //뉴스 조회 API
+    @GetMapping("/{id}")
+    public ApiResponse<MockNewsDTO> getById(@PathVariable Long id) {
+        MockNewsDTO mockNewsDTO = mockNewsService.getById(id);
+
+        return ApiResponse.of(mockNewsDTO);
+    }
+
+    @PatchMapping("/{id}")
+    public ApiResponse<MockNewsDTO> updateNews(@PathVariable Long id, @RequestBody NewsUpdateRequest request) {
+        MockNewsDTO mockNewsDTO = mockNewsService.updateNews(id, request);
+
+        return ApiResponse.of(mockNewsDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<String> deleteNews(@PathVariable Long id) {
+        mockNewsService.deleteNews(id);
+
+        return ApiResponse.of("삭제 성공");
+    }
+
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/dto/MockNewsDTO.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/dto/MockNewsDTO.java
@@ -1,0 +1,23 @@
+package com.ll.server.domain.mock.news.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MockNewsDTO {
+    private Long id;
+    private String title;
+    private String content;
+    private String author;
+    private String publisher; // From Publisher entity
+    private String imageUrl;
+    private String thumbnailUrl;
+    private String contentUrl;
+
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/dto/MockNewsResponse.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/dto/MockNewsResponse.java
@@ -1,0 +1,17 @@
+package com.ll.server.domain.mock.news.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MockNewsResponse {
+    List<MockNewsDTO> newsList;
+    long count;
+
+    public MockNewsResponse(List<MockNewsDTO> newsList){
+        this.newsList=newsList;
+        count=newsList.size();
+    }
+
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/dto/NewsUpdateRequest.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/dto/NewsUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.ll.server.domain.mock.news.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NewsUpdateRequest {
+    private String title;
+    private String content;
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/entity/MockNews.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/entity/MockNews.java
@@ -1,0 +1,26 @@
+package com.ll.server.domain.mock.news.entity;
+
+import com.ll.server.global.jpa.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "news")
+@AllArgsConstructor
+@NoArgsConstructor
+@SuperBuilder
+@ToString(callSuper = true)
+public class MockNews extends BaseEntity {
+    private String title;
+    @Column(columnDefinition = "TEXT")
+    private String content;
+    private String publisher;
+    private String author;
+    private String imageUrl;
+    private String thumbnailUrl;
+    private String contentUrl;
+
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/repository/MockNewsRepository.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/repository/MockNewsRepository.java
@@ -1,0 +1,9 @@
+package com.ll.server.domain.mock.news.repository;
+
+import com.ll.server.domain.mock.news.entity.MockNews;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MockNewsRepository extends JpaRepository<MockNews, Long> {
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/service/MockNewsService.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/service/MockNewsService.java
@@ -1,0 +1,122 @@
+package com.ll.server.domain.mock.news.service;
+
+import com.ll.server.domain.mock.news.dto.MockNewsDTO;
+import com.ll.server.domain.mock.news.dto.MockNewsResponse;
+import com.ll.server.domain.mock.news.dto.NewsUpdateRequest;
+import com.ll.server.domain.mock.news.entity.MockNews;
+import com.ll.server.domain.mock.news.repository.MockNewsRepository;
+import com.ll.server.domain.news.news.dto.NewsFetchParam;
+import com.ll.server.domain.news.news.service.NewsApiClient;
+import com.ll.server.domain.notification.Notify;
+import com.ll.server.global.response.enums.ReturnCode;
+import com.ll.server.global.response.exception.CustomLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MockNewsService {
+    private final MockNewsRepository mockNewsRepository;
+    private final NewsApiClient newsApiClient;
+    private final int DEFAULT_PAGE_SIZE = 100;
+
+    public List<MockNewsDTO> getAll() {
+        return mockNewsRepository.findAll()
+                .stream().map(this::convertToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Notify
+    public MockNewsDTO saveForTest(MockNews news){
+        return convertToDTO(mockNewsRepository.save(news));
+    }
+
+    @Notify
+    public MockNewsResponse fetchNews() {
+        LocalDateTime now = LocalDateTime.now();
+        String dateFrom = now.minusHours(6).format(DateTimeFormatter.ISO_LOCAL_DATE);
+        String dateTo = now.format(DateTimeFormatter.ISO_LOCAL_DATE);
+
+        List<NewsFetchParam> politicArticles = newsApiClient.getArticles("politics", dateFrom, dateTo, DEFAULT_PAGE_SIZE).getData();
+        List<NewsFetchParam> globalPoliticArticles = newsApiClient.getGlobalArticles("politics", dateFrom, dateTo, DEFAULT_PAGE_SIZE).getData()
+                .stream()
+                .map(global -> NewsFetchParam.builder()
+                        .title(global.getTitleKo())
+                        .publisher(global.getPublisher())
+                        .author(global.getAuthor())
+                        .summary(global.getSummaryKo())
+                        .imageUrl(global.getImageUrl())
+                        .thumbnailUrl(global.getThumbnailUrl())
+                        .contentUrl(global.getContentUrl())
+                        .publishedAt(global.getPublishedAt())
+                        .build())
+                .toList();
+
+
+        List<MockNews> mockNewsList = Stream.concat(
+                convertToNews(politicArticles).stream(),
+                convertToNews(globalPoliticArticles).stream()
+        ).collect(Collectors.toList());
+
+        return new MockNewsResponse(
+                mockNewsRepository.saveAll(mockNewsList)
+                .stream().map(this::convertToDTO)
+                .collect(Collectors.toList())
+        );
+
+    }
+
+    private List<MockNews> convertToNews(List<NewsFetchParam> fetchParams) {
+        return fetchParams.stream()
+                .map(param -> MockNews.builder()
+                        .title(param.getTitle())
+                        .content(param.getSummary())
+                        .author(param.getAuthor())
+                        .imageUrl(param.getImageUrl())
+                        .thumbnailUrl(param.getThumbnailUrl())
+                        .contentUrl(param.getContentUrl())
+                        .createDate(LocalDateTime.parse(param.getPublishedAt().replace("Z", "")))
+                        .build()
+                ).collect(Collectors.toList());
+    }
+
+      public MockNewsDTO getById(Long id) {
+        return convertToDTO(mockNewsRepository.findById(id).orElseThrow(() -> new CustomLogicException(ReturnCode.NOT_FOUND_ENTITY)));
+    }
+
+    // Convert News Entity to DTO
+    public MockNewsDTO convertToDTO(MockNews mockNews) {
+        return new MockNewsDTO(
+                mockNews.getId(),
+                mockNews.getTitle(),
+                mockNews.getContent(),
+                mockNews.getAuthor(),
+                mockNews.getPublisher(), // Assuming Publisher has a getter for its name
+                mockNews.getImageUrl(),
+                mockNews.getThumbnailUrl(),
+                mockNews.getContentUrl()
+        );
+    }
+
+    @Transactional
+    public MockNewsDTO updateNews(Long id, NewsUpdateRequest request) {
+        MockNews mockNews = mockNewsRepository.findById(id).orElseThrow(() -> new CustomLogicException(ReturnCode.NOT_FOUND_ENTITY));
+        mockNews.setTitle(request.getTitle());
+        mockNews.setContent(request.getContent());
+
+        return convertToDTO(mockNews);
+    }
+
+    @Transactional
+    public void deleteNews(Long id) {
+        mockNewsRepository.deleteById(id);
+    }
+}

--- a/server/src/main/java/com/ll/server/domain/mock/repost/dto/MockRepostDTO.java
+++ b/server/src/main/java/com/ll/server/domain/mock/repost/dto/MockRepostDTO.java
@@ -5,9 +5,9 @@ import com.ll.server.domain.mock.comment.dto.MockCommentDTO;
 import com.ll.server.domain.mock.comment.dto.MockCommentResponse;
 import com.ll.server.domain.mock.like.dto.MockLikeDTO;
 import com.ll.server.domain.mock.like.dto.MockLikeResponse;
+import com.ll.server.domain.mock.news.entity.MockNews;
 import com.ll.server.domain.mock.repost.entity.MockRepost;
 import com.ll.server.domain.news.news.dto.NewsDTO;
-import com.ll.server.domain.news.news.entity.News;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,9 +29,9 @@ public class MockRepostDTO {
     private MockLikeResponse likeInfo;
 
     public MockRepostDTO(MockRepost repost){
-        News newsEntity=repost.getNews();
+        MockNews newsEntity=repost.getNews();
         news= NewsDTO.builder()
-                .publisherName(newsEntity.getPublisher().getPublisher())
+                .publisherName(newsEntity.getPublisher())
                 .author(newsEntity.getAuthor())
                 .id(newsEntity.getId())
                 .title(newsEntity.getTitle())

--- a/server/src/main/java/com/ll/server/domain/mock/repost/entity/MockRepost.java
+++ b/server/src/main/java/com/ll/server/domain/mock/repost/entity/MockRepost.java
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.ll.server.domain.mention.repostmention.entity.RepostMention;
 import com.ll.server.domain.mock.comment.entity.MockComment;
 import com.ll.server.domain.mock.like.entity.MockLike;
+import com.ll.server.domain.mock.news.entity.MockNews;
 import com.ll.server.domain.mock.user.entity.MockUser;
-import com.ll.server.domain.news.news.entity.News;
 import com.ll.server.global.jpa.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -23,7 +23,7 @@ import java.util.List;
 @ToString
 public class MockRepost extends BaseEntity {
     @ManyToOne(fetch=FetchType.LAZY)
-    private News news;
+    private MockNews news;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private MockUser user;

--- a/server/src/main/java/com/ll/server/domain/mock/repost/service/MockRepostService.java
+++ b/server/src/main/java/com/ll/server/domain/mock/repost/service/MockRepostService.java
@@ -5,14 +5,14 @@ import com.ll.server.domain.mock.comment.dto.MockCommentWriteRequest;
 import com.ll.server.domain.mock.comment.entity.MockComment;
 import com.ll.server.domain.mock.like.dto.MockLikeDTO;
 import com.ll.server.domain.mock.like.entity.MockLike;
+import com.ll.server.domain.mock.news.entity.MockNews;
+import com.ll.server.domain.mock.news.repository.MockNewsRepository;
 import com.ll.server.domain.mock.repost.dto.MockRepostDTO;
 import com.ll.server.domain.mock.repost.dto.MockRepostWriteRequest;
 import com.ll.server.domain.mock.repost.entity.MockRepost;
 import com.ll.server.domain.mock.repost.repository.MockRepostRepository;
 import com.ll.server.domain.mock.user.entity.MockUser;
 import com.ll.server.domain.mock.user.repository.MockUserRepository;
-import com.ll.server.domain.news.news.entity.News;
-import com.ll.server.domain.news.news.repository.NewsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 public class MockRepostService {
     private final MockRepostRepository repostRepository;
     private final MockUserRepository userRepository;
-    private final NewsRepository newsRepository;
+    private final MockNewsRepository newsRepository;
 
 
     public MockRepostDTO findById(Long id){
@@ -52,7 +52,7 @@ public class MockRepostService {
     public MockRepostDTO save(MockRepostWriteRequest request){
         MockUser user=userRepository.findById(request.getWriterId()).get();
 
-        News news=newsRepository.findAll()
+        MockNews news=newsRepository.findAll()
                 .stream()
                 .filter(n -> n.getId().equals(request.getNewsId()))
                 .findFirst()

--- a/server/src/main/java/com/ll/server/domain/mock/user/dto/MockUserSignupRequest.java
+++ b/server/src/main/java/com/ll/server/domain/mock/user/dto/MockUserSignupRequest.java
@@ -1,5 +1,6 @@
 package com.ll.server.domain.mock.user.dto;
 
+import com.ll.server.domain.mock.user.MockRole;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,5 +12,7 @@ public class MockUserSignupRequest {
     private String email;
     private String password;
     private String nickname;
+
+    private MockRole role;
 
 }

--- a/server/src/main/java/com/ll/server/domain/mock/user/service/MockUserService.java
+++ b/server/src/main/java/com/ll/server/domain/mock/user/service/MockUserService.java
@@ -23,6 +23,7 @@ public class MockUserService {
                         .email(request.getEmail())
                         .password(request.getPassword())
                         .nickname(request.getNickname())
+                        .role(request.getRole())
                         .build();
         MockUser find=userRepository.findByEmail(request.getEmail());
 

--- a/server/src/main/java/com/ll/server/domain/news/news/controller/ApiV1NewsController.java
+++ b/server/src/main/java/com/ll/server/domain/news/news/controller/ApiV1NewsController.java
@@ -5,15 +5,10 @@ import com.ll.server.domain.news.news.dto.NewsUpdateRequest;
 import com.ll.server.domain.news.news.entity.News;
 import com.ll.server.domain.news.news.service.NewsService;
 import com.ll.server.global.response.response.ApiResponse;
-import lombok.Builder;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,7 +16,6 @@ import java.util.Map;
 public class ApiV1NewsController {
 
     private final NewsService newsService;
-    private final OpenAiChatModel openAiChatModel;
 
     @GetMapping
     public List<News> getAll() {
@@ -52,84 +46,4 @@ public class ApiV1NewsController {
         return ApiResponse.of("삭제 성공");
     }
 
-
-    //임시로 만든 함수. 실제 구현 시에는 이 부분은 LLM과의 통신을 하는 private 메서드가 될 예정이다.
-    //실제 동작 시에는 /api/news/analyze에서 request로 넘어온 id들을 newsService에서 ID로 news를 하나하나 찾아서 List에 담고
-    //analyze가 매핑된 메서드에서 해당 메서드를 호출하면서 news의 List를 넘긴다.
-    //해당 메서드에서 내부에서 하나하나 DTO로 바꾼 뒤 getAiResponse를 호출해 그 값을 반환하면 된다.
-    @PostMapping("/ai")
-    public String gptApiTest(@RequestBody Map<String, String> request){
-        return getAiResponse(extractNews(request));
-    }
-
-    @RequiredArgsConstructor
-    @Builder
-    @Getter
-    static class TestDTO{
-        private final String country;
-        private final String publisher;
-        private final String summary;
-    }
-
-    @GetMapping("/fetchNews")
-    public void fetchNews() {
-        newsService.fetchNews();
-    }
-
-    private List<TestDTO> extractNews(Map<String,String> articleMap){
-        List<String> summaryList=new ArrayList<>();
-        for(int i=0;i<articleMap.keySet().size();i++){
-            String keyName="article"+(i+1);
-            if(articleMap.containsKey(keyName)){
-                String summary=articleMap.get(keyName);
-                if(summary!=null && !summary.isBlank()) summaryList.add(articleMap.get(keyName));
-            }
-        }
-
-        List<TestDTO> newsList=new ArrayList<>();
-
-        addArticle(newsList, summaryList);
-
-        return newsList;
-    }
-
-    private void addArticle(List<TestDTO> newsList,List<String> summaryList) {
-        if(summaryList.size()<2) throw new RuntimeException("유효하지 않은 요청입니다.");
-
-        for(int i=0;i< summaryList.size();i++) {
-            newsList.add(
-                    TestDTO.builder()
-                            .country("나라"+(i+1))
-                            .publisher("언론사"+(i+1))
-                            .summary(summaryList.get(i))
-                            .build()
-            );
-        }
-    }
-
-    private String getAiResponse(List<TestDTO> newsList){
-        StringBuilder promptBuilder=new StringBuilder();
-        for(int i=0;i<newsList.size();i++){
-            promptBuilder.append("기사").append(i+1).append(": ").append(newsList.get(i).getSummary()).append("\n");
-        }
-
-        for(int i=0;i<newsList.size();i++){
-            promptBuilder.append("기사").append(i+1).append("은 ")
-                    .append(newsList.get(i).getCountry()).append(" ").append(newsList.get(i).getPublisher()).append("언론사의 기사 요약문");
-            if(i<newsList.size()-1) {
-                promptBuilder.append("이고, ");
-            }else{
-                promptBuilder.append("이야.\n");
-            }
-        }
-
-        promptBuilder.append(newsList.size()).append("개 기사는 비슷한 주제를 다루는 기사들이야.\n");
-        promptBuilder.append(newsList.size()).append("개 기사 요약문을 읽고 그 주제가 무엇인지 알아낸 다음, 주제를 간단히 서술해. 그 다음 각 기사에 대해 아래 양식만 써서 답변을 해.\n");
-        promptBuilder.append("(나라 이름) - (언론사)\n");
-        promptBuilder.append("강조 포인트: (기사에서 강조하는 부분이 어디인지로 채워줘)\n");
-        promptBuilder.append("어조: (어떤 어조로 기사를 작성했는지로 채워줘)\n");
-        promptBuilder.append("바라보는 관점: (어떤 관점으로 해당 주제를 바라보는지로 채워줘)\n");
-
-        return openAiChatModel.call(promptBuilder.toString());
-    }
 }

--- a/server/src/main/java/com/ll/server/domain/notification/dto/NotificationDTO.java
+++ b/server/src/main/java/com/ll/server/domain/notification/dto/NotificationDTO.java
@@ -16,6 +16,7 @@ public class NotificationDTO {
     private String url;
 
     public NotificationDTO(Notification notification){
+        if(notification==null) return;
         id=notification.getId();
         message=notification.getMessage();
         url=notification.getUrl();

--- a/server/src/main/java/com/ll/server/global/jpa/DataLoader.java
+++ b/server/src/main/java/com/ll/server/global/jpa/DataLoader.java
@@ -3,16 +3,16 @@ package com.ll.server.global.jpa;
 import com.ll.server.domain.mock.comment.dto.MockCommentWriteRequest;
 import com.ll.server.domain.mock.follow.controller.ApiV1MockFollowController;
 import com.ll.server.domain.mock.follow.dto.MockFollowRequest;
+import com.ll.server.domain.mock.news.entity.MockNews;
+import com.ll.server.domain.mock.news.service.MockNewsService;
 import com.ll.server.domain.mock.repost.controller.ApiV1MockRepostController;
 import com.ll.server.domain.mock.repost.dto.MockRepostDTO;
 import com.ll.server.domain.mock.repost.dto.MockRepostWriteRequest;
 import com.ll.server.domain.mock.repost.repository.MockRepostRepository;
+import com.ll.server.domain.mock.user.MockRole;
 import com.ll.server.domain.mock.user.dto.MockUserSignupRequest;
 import com.ll.server.domain.mock.user.entity.MockUser;
 import com.ll.server.domain.mock.user.service.MockUserService;
-import com.ll.server.domain.news.news.entity.News;
-import com.ll.server.domain.news.news.entity.Publisher;
-import com.ll.server.domain.news.news.enums.Country;
 import com.ll.server.domain.news.news.repository.NewsPublisherRepository;
 import com.ll.server.domain.news.news.repository.NewsRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +27,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class DataLoader implements CommandLineRunner {
     private final NewsRepository newsRepository;
+    private final MockNewsService newsService;
     private final NewsPublisherRepository newsPublisherRepository;
     private final MockUserService userService;
     private final ApiV1MockFollowController followController;
@@ -36,14 +37,14 @@ public class DataLoader implements CommandLineRunner {
     @Override
     @Transactional
     public void run(String... args) throws Exception {
-        // Publisher 객체 생성 (Country enum 값 사용)
-        Publisher publisher = new Publisher("Test Publisher", Country.USA); // Publisher는 Country 값을 받습니다.
-        newsPublisherRepository.save(publisher);
-        // News 객체 생성
-        News news = new News("Test News", "This is a test news content", publisher, "John Doe",
-                "http://example.com/image.jpg", "http://example.com/thumbnail.jpg",
-                "http://example.com");
-        newsRepository.save(news);
+
+        MockUserSignupRequest publisherSignup=MockUserSignupRequest.builder()
+                .email("publisher@example.com")
+                .nickname("Test Publisher")
+                .password("1234")
+                .role(MockRole.PUBLISHER)
+                .build();
+        MockUser publisherUser=userService.signup(publisherSignup);
 
         List<MockUser> users=new ArrayList<>();
         for(int i=0;i<3;i++){
@@ -51,6 +52,7 @@ public class DataLoader implements CommandLineRunner {
                     .email((i+1)+"@example.com")
                     .nickname("user"+(i+1))
                     .password("1234")
+                    .role(MockRole.USER)
                     .build();
             users.add(userService.signup(signupRequest));
         }
@@ -59,6 +61,12 @@ public class DataLoader implements CommandLineRunner {
         MockUser user2=users.get(1);
         MockUser user3=users.get(2);
 
+        MockFollowRequest followPublisher=MockFollowRequest.builder()
+                .followerId(publisherUser.getId())
+                .followeeId(user1.getId())
+                .build();
+        followController.follow(followPublisher);
+        //user1이 테스트 언론사를 구독. 알림 1개째
 
         MockFollowRequest followRequest1=MockFollowRequest.builder()
                 .followerId(user1.getId())
@@ -70,7 +78,19 @@ public class DataLoader implements CommandLineRunner {
                 .followeeId(user3.getId())
                 .build();
         followController.follow(followRequest1);
+        //user2가 user1을 구독. 알림 2개째
+        
         followController.follow(followRequest2);
+        //user3가 user1을 구독. 알림 3개째
+
+
+        // News 객체 생성
+        MockNews news = new MockNews("Test News", "This is a test news content", "Test Publisher", "John Doe",
+                "http://example.com/image.jpg", "http://example.com/thumbnail.jpg",
+                "http://example.com");
+        newsService.saveForTest(news);
+        //user1에게 구독 사실을 전송. 알림 4개째.
+
 
         MockRepostWriteRequest repostRequest1=MockRepostWriteRequest.builder()
                 .content("연습용1")
@@ -79,6 +99,7 @@ public class DataLoader implements CommandLineRunner {
                 .writerId(user1.getId())
                 .build();
         MockRepostDTO repostDTO1=repostController.write(repostRequest1);
+        //user1이 작성한 글이므로 user2/3에게 알림이 가고, 멘션을 2와 3에게 했으므로 알림이 감. 알림 8개째.
 
         MockRepostWriteRequest repostRequest2=MockRepostWriteRequest.builder()
                 .content("연습용2")
@@ -105,6 +126,7 @@ public class DataLoader implements CommandLineRunner {
                             .build();
             repostController.addComment(repostDTO1.getRepostId(),commentWriteRequest);
         }
+        //user2, user3가 user1의 리포스트에 댓글. user1, user2가 멘션. 알림 12개.
 
         for(int i=0;i<3;i++){
             MockCommentWriteRequest commentWriteRequest=
@@ -115,6 +137,7 @@ public class DataLoader implements CommandLineRunner {
                             .build();
             repostController.addComment(repostDTO2.getRepostId(),commentWriteRequest);
         }
+        //16개
 
         for(int i=0;i<3;i++){
             MockCommentWriteRequest commentWriteRequest=
@@ -125,10 +148,12 @@ public class DataLoader implements CommandLineRunner {
                             .build();
             repostController.addComment(repostDTO3.getRepostId(),commentWriteRequest);
         }
+        //20개
 
         repostController.markLike(repostDTO1.getRepostId(),user2.getId());
         repostController.markLike(repostDTO2.getRepostId(),user3.getId());
         repostController.markLike(repostDTO3.getRepostId(),user1.getId());
+        //23개
 
     }
 }


### PR DESCRIPTION
알림 기능으로 보낸 메시지들을 확인해보니 의도한대로 보내지는 건 맞는데 메시지가 이상한 점을 고쳤습니다.
그리고 MockNews를 따로 만들어두고 그걸 바탕으로 뉴스 구독 기능을 모의로 구현해보았습니다.
언론사 유저의 닉네임을 무조건 언론사 이름과 똑같도록 제약을 한다면 언론사 이름을 통해 Follow 테이블에서 Follow 관계를 찾아온 뒤에 팔로우한 유저들을 찾아올 수 있을 것이라는 전제로 구현한 것입니다.