### PR TITLE
feat: configure userprofile data temporarily

### DIFF
--- a/server/src/main/java/com/ll/server/domain/mock/comment/repository/MockCommentRepository.java
+++ b/server/src/main/java/com/ll/server/domain/mock/comment/repository/MockCommentRepository.java
@@ -1,0 +1,11 @@
+package com.ll.server.domain.mock.comment.repository;
+
+import com.ll.server.domain.mock.comment.entity.MockComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MockCommentRepository extends JpaRepository<MockComment,Long> {
+
+    List<MockComment> findMockCommentsByUser_Id(Long userId);
+}

--- a/server/src/main/java/com/ll/server/domain/mock/follow/dto/FolloweeListResponse.java
+++ b/server/src/main/java/com/ll/server/domain/mock/follow/dto/FolloweeListResponse.java
@@ -1,12 +1,25 @@
 package com.ll.server.domain.mock.follow.dto;
 
+import com.ll.server.domain.mock.follow.entity.MockFollow;
+import com.ll.server.domain.mock.user.dto.MockUserDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @AllArgsConstructor
 public class FolloweeListResponse {
-    List<String> followees;
+    private List<MockUserDTO> followees=new ArrayList<>();
+    private long count;
+
+    public FolloweeListResponse(List<MockFollow> follows){
+        for(MockFollow follow:follows){
+            followees.add(
+                    new MockUserDTO(follow.getFollowee())
+            );
+        }
+        count=followees.size();
+    }
 }

--- a/server/src/main/java/com/ll/server/domain/mock/follow/dto/FollowerListResponse.java
+++ b/server/src/main/java/com/ll/server/domain/mock/follow/dto/FollowerListResponse.java
@@ -1,12 +1,25 @@
 package com.ll.server.domain.mock.follow.dto;
 
+import com.ll.server.domain.mock.follow.entity.MockFollow;
+import com.ll.server.domain.mock.user.dto.MockUserDTO;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @AllArgsConstructor
 @Getter
 public class FollowerListResponse {
-    List<String> followers;
+    private List<MockUserDTO> followers=new ArrayList<>();;
+    private long count;
+
+    public FollowerListResponse(List<MockFollow> follows){
+        for(MockFollow follow:follows){
+            followers.add(
+                    new MockUserDTO(follow.getFollower())
+            );
+        }
+        count=followers.size();
+    }
 }

--- a/server/src/main/java/com/ll/server/domain/mock/follow/service/MockFollowService.java
+++ b/server/src/main/java/com/ll/server/domain/mock/follow/service/MockFollowService.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -55,25 +54,15 @@ public class MockFollowService {
 
     public FolloweeListResponse findFollowees(String followerName){
         List<MockFollow> follows=mockFollowRepository.findMockFollowsByFollower_Nickname(followerName);
-        List<String> followees=new ArrayList<>();
 
-        for(MockFollow follow: follows){
-            followees.add(follow.getFollowee().getNickname());
-        }
-
-        return new FolloweeListResponse(followees);
+        return new FolloweeListResponse(follows);
     }
 
 
     public FollowerListResponse findFollowers(String followeeName){
         List<MockFollow> follows=mockFollowRepository.findMockFollowsByFollowee_Nickname(followeeName);
-        List<String> followees=new ArrayList<>();
 
-        for(MockFollow follow: follows){
-            followees.add(follow.getFollower().getNickname());
-        }
-
-        return new FollowerListResponse(followees);
+        return new FollowerListResponse(follows);
     }
 
     public MockFollowDTO findByFollowerNameAndFolloweeName(String followerName,String followeeName){

--- a/server/src/main/java/com/ll/server/domain/mock/like/repository/MockLikeRepository.java
+++ b/server/src/main/java/com/ll/server/domain/mock/like/repository/MockLikeRepository.java
@@ -1,0 +1,10 @@
+package com.ll.server.domain.mock.like.repository;
+
+import com.ll.server.domain.mock.like.entity.MockLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MockLikeRepository extends JpaRepository<MockLike,Long> {
+    List<MockLike> findMockLikesByUser_Id(Long userId);
+}

--- a/server/src/main/java/com/ll/server/domain/mock/news/dto/MockNewsDTO.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/dto/MockNewsDTO.java
@@ -1,6 +1,7 @@
 package com.ll.server.domain.mock.news.dto;
 
 
+import com.ll.server.domain.mock.news.entity.MockNews;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,5 +20,16 @@ public class MockNewsDTO {
     private String imageUrl;
     private String thumbnailUrl;
     private String contentUrl;
+
+    public MockNewsDTO(MockNews news){
+        id=news.getId();
+        title=news.getTitle();
+        content=news.getContent();
+        author=news.getAuthor();
+        publisher=news.getPublisher();
+        imageUrl=news.getImageUrl();
+        thumbnailUrl=news.getThumbnailUrl();
+        contentUrl=news.getContentUrl();
+    }
 
 }

--- a/server/src/main/java/com/ll/server/domain/mock/news/repository/MockNewsRepository.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/repository/MockNewsRepository.java
@@ -4,6 +4,9 @@ import com.ll.server.domain.mock.news.entity.MockNews;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MockNewsRepository extends JpaRepository<MockNews, Long> {
+    List<MockNews> findMockNewsByPublisher(String publisher);
 }

--- a/server/src/main/java/com/ll/server/domain/mock/news/service/MockNewsService.java
+++ b/server/src/main/java/com/ll/server/domain/mock/news/service/MockNewsService.java
@@ -92,6 +92,10 @@ public class MockNewsService {
         return convertToDTO(mockNewsRepository.findById(id).orElseThrow(() -> new CustomLogicException(ReturnCode.NOT_FOUND_ENTITY)));
     }
 
+    public List<MockNewsDTO> getByPublisher(String publisher){
+        return mockNewsRepository.findMockNewsByPublisher(publisher).stream().map(this::convertToDTO).collect(Collectors.toList());
+    }
+
     // Convert News Entity to DTO
     public MockNewsDTO convertToDTO(MockNews mockNews) {
         return new MockNewsDTO(

--- a/server/src/main/java/com/ll/server/domain/mock/user/controller/ApiV1MockUserController.java
+++ b/server/src/main/java/com/ll/server/domain/mock/user/controller/ApiV1MockUserController.java
@@ -3,13 +3,11 @@ package com.ll.server.domain.mock.user.controller;
 
 import com.ll.server.domain.mock.user.dto.MockUserLoginRequest;
 import com.ll.server.domain.mock.user.dto.MockUserSignupRequest;
+import com.ll.server.domain.mock.user.dto.UserProfile;
 import com.ll.server.domain.mock.user.entity.MockUser;
 import com.ll.server.domain.mock.user.service.MockUserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +31,11 @@ public class ApiV1MockUserController {
         if(user==null) return "로그인 실패";
 
         return "로그인 성공";
+    }
+
+    @GetMapping("/{userId}")
+    public UserProfile getProfile(@PathVariable("userId") Long userId){
+        return userService.getProfile(userId);
     }
 
 

--- a/server/src/main/java/com/ll/server/domain/mock/user/dto/UserProfile.java
+++ b/server/src/main/java/com/ll/server/domain/mock/user/dto/UserProfile.java
@@ -1,0 +1,39 @@
+package com.ll.server.domain.mock.user.dto;
+
+import com.ll.server.domain.mock.comment.dto.MockCommentDTO;
+import com.ll.server.domain.mock.follow.dto.FolloweeListResponse;
+import com.ll.server.domain.mock.follow.dto.FollowerListResponse;
+import com.ll.server.domain.mock.news.dto.MockNewsDTO;
+import com.ll.server.domain.mock.repost.dto.MockRepostDTO;
+import com.ll.server.domain.mock.user.entity.MockUser;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class UserProfile {
+    private MockUserDTO userInfo;
+    private List<MockRepostDTO> reposts;
+    private List<MockRepostDTO> likeReposts;
+    private List<MockCommentDTO> comments;
+    private List<MockNewsDTO> news;
+    private FolloweeListResponse followees;
+    private FollowerListResponse followers;
+    private String profileUrl;
+
+    public UserProfile(MockUser user, FolloweeListResponse followees, FollowerListResponse followers, List<MockRepostDTO> likeReposts, List<MockCommentDTO> comments){
+        userInfo=new MockUserDTO(user);
+        reposts=user.getReposts().stream().map(MockRepostDTO::new).collect(Collectors.toList());
+        this.likeReposts=likeReposts;
+        profileUrl=user.getProfileUrl();
+        this.followees=followees;
+        this.followers=followers;
+        this.comments=comments;
+    }
+
+    public UserProfile(MockUser user,FolloweeListResponse followees, FollowerListResponse followers, List<MockRepostDTO> likeReposts, List<MockCommentDTO> comments,List<MockNewsDTO> news){
+        this(user,followees,followers,likeReposts,comments);
+        this.news=news;
+    }
+}

--- a/server/src/main/java/com/ll/server/domain/mock/user/service/MockUserService.java
+++ b/server/src/main/java/com/ll/server/domain/mock/user/service/MockUserService.java
@@ -1,7 +1,20 @@
 package com.ll.server.domain.mock.user.service;
 
+import com.ll.server.domain.mock.comment.dto.MockCommentDTO;
+import com.ll.server.domain.mock.comment.repository.MockCommentRepository;
+import com.ll.server.domain.mock.follow.dto.FolloweeListResponse;
+import com.ll.server.domain.mock.follow.dto.FollowerListResponse;
+import com.ll.server.domain.mock.follow.entity.MockFollow;
+import com.ll.server.domain.mock.follow.repository.MockFollowRepository;
+import com.ll.server.domain.mock.like.entity.MockLike;
+import com.ll.server.domain.mock.like.repository.MockLikeRepository;
+import com.ll.server.domain.mock.news.dto.MockNewsDTO;
+import com.ll.server.domain.mock.news.repository.MockNewsRepository;
+import com.ll.server.domain.mock.repost.dto.MockRepostDTO;
+import com.ll.server.domain.mock.user.MockRole;
 import com.ll.server.domain.mock.user.dto.MockUserLoginRequest;
 import com.ll.server.domain.mock.user.dto.MockUserSignupRequest;
+import com.ll.server.domain.mock.user.dto.UserProfile;
 import com.ll.server.domain.mock.user.entity.MockUser;
 import com.ll.server.domain.mock.user.repository.MockUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,12 +22,17 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MockUserService {
     private final MockUserRepository userRepository;
+    private final MockFollowRepository mockFollowRepository;
+    private final MockNewsRepository newsRepository;
+    private final MockLikeRepository likeRepository;
+    private final MockCommentRepository mockCommentRepository;
 
     @Transactional
     public MockUser signup(MockUserSignupRequest request){
@@ -42,5 +60,33 @@ public class MockUserService {
 
     public List<MockUser> findUsersByNickNameIn(List<String> nicknames){
         return userRepository.findMockUsersByNicknameIn(nicknames);
+    }
+
+    public UserProfile getProfile(Long userId){
+        Optional<MockUser> targetOptional=userRepository.findById(userId);
+        if(targetOptional.isEmpty()) return null;
+
+        MockUser target=targetOptional.get();
+        List<MockFollow> followeeList=mockFollowRepository.findMockFollowsByFollower_Id(target.getId());
+        List<MockFollow> followerList=mockFollowRepository.findMockFollowsByFollowee_Id(target.getId());
+
+        FolloweeListResponse followees=new FolloweeListResponse(followeeList);
+        FollowerListResponse followers=new FollowerListResponse(followerList);
+
+        List<MockLike> likes=likeRepository.findMockLikesByUser_Id(userId);
+        List<MockRepostDTO> likeReposts=likes.stream().map(like -> new MockRepostDTO(like.getRepost())).toList();
+
+        List<MockCommentDTO> comments=mockCommentRepository.findMockCommentsByUser_Id(userId)
+                .stream().map(MockCommentDTO::new).toList();
+
+        if(target.getRole().equals(MockRole.PUBLISHER)){
+            List<MockNewsDTO> news=newsRepository.findMockNewsByPublisher(target.getNickname())
+                    .stream().map(MockNewsDTO::new).toList();
+            return new UserProfile(target,followees,followers,likeReposts,comments,news);
+        }
+
+        return new UserProfile(target,followees,followers,likeReposts,comments);
+
+
     }
 }


### PR DESCRIPTION
유저 프로필을 눌렀을 때 보여야할 데이터를 임시로 구성해보았습니다.
일단 프론트로 가는 정보의 양이 생각보다 많기도 하고, 쿼리도 생각보다 많이 필요한 것 같습니다.
추후에 이 정보들에 대한 페이징을 어떻게 할지도 생각해볼 문제인 것 같습니다.